### PR TITLE
Add C++ skeleton and bindings for Pi0 policy

### DIFF
--- a/src/lerobot/policies/pi0/cpp/CMakeLists.txt
+++ b/src/lerobot/policies/pi0/cpp/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+project(pi0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Torch REQUIRED)
+find_package(pybind11 CONFIG REQUIRED)
+
+add_library(pi0 STATIC
+    src/pi0.cpp
+)
+
+target_include_directories(pi0 PUBLIC include)
+target_link_libraries(pi0 PUBLIC ${TORCH_LIBRARIES})
+
+pybind11_add_module(pi0_cpp src/bindings.cpp)
+target_link_libraries(pi0_cpp PRIVATE pi0 ${TORCH_LIBRARIES})
+

--- a/src/lerobot/policies/pi0/cpp/__init__.py
+++ b/src/lerobot/policies/pi0/cpp/__init__.py
@@ -1,0 +1,6 @@
+"""Python bindings for C++ Pi0 implementation."""
+
+from .pi0_cpp import Config, Pi0, create_pi0
+
+__all__ = ["Config", "Pi0", "create_pi0"]
+

--- a/src/lerobot/policies/pi0/cpp/include/pi0/config.h
+++ b/src/lerobot/policies/pi0/cpp/include/pi0/config.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+
+namespace lerobot {
+namespace pi0 {
+
+struct Config {
+    int64_t n_obs_steps = 1;
+    int64_t chunk_size = 50;
+    int64_t n_action_steps = 50;
+};
+
+} // namespace pi0
+} // namespace lerobot
+

--- a/src/lerobot/policies/pi0/cpp/include/pi0/pi0.h
+++ b/src/lerobot/policies/pi0/cpp/include/pi0/pi0.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+#include <torch/torch.h>
+#include "pi0/config.h"
+
+namespace lerobot {
+namespace pi0 {
+
+class Pi0 : public torch::nn::Module {
+public:
+    explicit Pi0(const Config& cfg);
+
+    torch::Tensor forward(const torch::Tensor& input);
+
+private:
+    Config cfg_;
+};
+
+std::shared_ptr<Pi0> create_pi0(const Config& cfg);
+
+} // namespace pi0
+} // namespace lerobot
+

--- a/src/lerobot/policies/pi0/cpp/src/bindings.cpp
+++ b/src/lerobot/policies/pi0/cpp/src/bindings.cpp
@@ -1,0 +1,23 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <torch/torch.h>
+#include "pi0/pi0.h"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(pi0_cpp, m) {
+    m.doc() = "C++ bindings for Pi0 policy";
+
+    py::class_<lerobot::pi0::Config>(m, "Config")
+        .def(py::init<>())
+        .def_readwrite("n_obs_steps", &lerobot::pi0::Config::n_obs_steps)
+        .def_readwrite("chunk_size", &lerobot::pi0::Config::chunk_size)
+        .def_readwrite("n_action_steps", &lerobot::pi0::Config::n_action_steps);
+
+    py::class_<lerobot::pi0::Pi0, std::shared_ptr<lerobot::pi0::Pi0>, torch::nn::Module>(m, "Pi0")
+        .def(py::init<const lerobot::pi0::Config&>())
+        .def("forward", &lerobot::pi0::Pi0::forward);
+
+    m.def("create_pi0", &lerobot::pi0::create_pi0, py::arg("cfg"));
+}
+

--- a/src/lerobot/policies/pi0/cpp/src/pi0.cpp
+++ b/src/lerobot/policies/pi0/cpp/src/pi0.cpp
@@ -1,0 +1,19 @@
+#include "pi0/pi0.h"
+
+namespace lerobot {
+namespace pi0 {
+
+Pi0::Pi0(const Config& cfg) : cfg_(cfg) {}
+
+torch::Tensor Pi0::forward(const torch::Tensor& input) {
+    // Placeholder implementation matching Python API.
+    return torch::zeros_like(input);
+}
+
+std::shared_ptr<Pi0> create_pi0(const Config& cfg) {
+    return std::make_shared<Pi0>(cfg);
+}
+
+} // namespace pi0
+} // namespace lerobot
+


### PR DESCRIPTION
## Summary
- add minimal C++ Pi0 class and Config struct under new cpp/ directory
- provide factory function and pybind11 module for Python access
- include CMake project setup for libtorch and bindings

## Testing
- `pre-commit run --files src/lerobot/policies/pi0/cpp/__init__.py src/lerobot/policies/pi0/cpp/CMakeLists.txt src/lerobot/policies/pi0/cpp/include/pi0/config.h src/lerobot/policies/pi0/cpp/include/pi0/pi0.h src/lerobot/policies/pi0/cpp/src/pi0.cpp src/lerobot/policies/pi0/cpp/src/bindings.cpp` *(fails: CalledProcessError: command: ('/root/.pyenv/versions/3.12.10/bin/python3.12', '-mvirtualenv', '/root/.cache/pre-commit/repozw5h80m5/py_env-python3.10', '-p', 'python3.10'))*
- `pytest tests/test_available.py::test_available_policies -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1a74ac074832ab537d055593f2801