### PR TITLE
Add C++ Pi0Model with TorchScript bindings

### DIFF
--- a/src/lerobot/policies/pi0/cpp/CMakeLists.txt
+++ b/src/lerobot/policies/pi0/cpp/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(pybind11 CONFIG REQUIRED)
 
 add_library(pi0 STATIC
     src/pi0.cpp
+    src/model.cpp
 )
 
 target_include_directories(pi0 PUBLIC include)

--- a/src/lerobot/policies/pi0/cpp/include/pi0/model.h
+++ b/src/lerobot/policies/pi0/cpp/include/pi0/model.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <torch/torch.h>
+
+namespace lerobot {
+namespace pi0 {
+
+// Simple configuration structure for Pi0Model components
+struct ModelConfig {
+    int64_t vocab_size{0};
+    int64_t embed_dim{0};
+    int64_t num_heads{0};
+    int64_t hidden_dim{0};
+};
+
+// A minimal C++ implementation mirroring Pi0Model architecture
+class Pi0Model : public torch::nn::Module {
+public:
+    explicit Pi0Model(const ModelConfig& cfg);
+
+    // Forward pass expecting token indices and state tensor
+    torch::Tensor forward(const torch::Tensor& tokens,
+                          const torch::Tensor& state);
+
+private:
+    ModelConfig cfg_;
+    torch::nn::Embedding token_embedding_{nullptr};
+    torch::nn::Linear state_proj_{nullptr};
+    torch::nn::MultiheadAttention attention_{nullptr};
+    torch::nn::Linear output_{nullptr};
+};
+
+} // namespace pi0
+} // namespace lerobot
+

--- a/src/lerobot/policies/pi0/cpp/src/bindings.cpp
+++ b/src/lerobot/policies/pi0/cpp/src/bindings.cpp
@@ -2,6 +2,7 @@
 #include <pybind11/stl.h>
 #include <torch/torch.h>
 #include "pi0/pi0.h"
+#include "pi0/model.h"
 
 namespace py = pybind11;
 
@@ -17,6 +18,17 @@ PYBIND11_MODULE(pi0_cpp, m) {
     py::class_<lerobot::pi0::Pi0, std::shared_ptr<lerobot::pi0::Pi0>, torch::nn::Module>(m, "Pi0")
         .def(py::init<const lerobot::pi0::Config&>())
         .def("forward", &lerobot::pi0::Pi0::forward);
+
+    py::class_<lerobot::pi0::ModelConfig>(m, "ModelConfig")
+        .def(py::init<>())
+        .def_readwrite("vocab_size", &lerobot::pi0::ModelConfig::vocab_size)
+        .def_readwrite("embed_dim", &lerobot::pi0::ModelConfig::embed_dim)
+        .def_readwrite("num_heads", &lerobot::pi0::ModelConfig::num_heads)
+        .def_readwrite("hidden_dim", &lerobot::pi0::ModelConfig::hidden_dim);
+
+    py::class_<lerobot::pi0::Pi0Model, std::shared_ptr<lerobot::pi0::Pi0Model>, torch::nn::Module>(m, "Pi0Model")
+        .def(py::init<const lerobot::pi0::ModelConfig&>())
+        .def("forward", &lerobot::pi0::Pi0Model::forward);
 
     m.def("create_pi0", &lerobot::pi0::create_pi0, py::arg("cfg"));
 }

--- a/src/lerobot/policies/pi0/cpp/src/model.cpp
+++ b/src/lerobot/policies/pi0/cpp/src/model.cpp
@@ -1,0 +1,42 @@
+#include "pi0/model.h"
+
+namespace lerobot {
+namespace pi0 {
+
+Pi0Model::Pi0Model(const ModelConfig& cfg) : cfg_(cfg) {
+    token_embedding_ = register_module("token_embedding", torch::nn::Embedding(cfg.vocab_size, cfg.embed_dim));
+    state_proj_ = register_module("state_proj", torch::nn::Linear(cfg.hidden_dim, cfg.embed_dim));
+    attention_ = register_module("attention", torch::nn::MultiheadAttention(
+        torch::nn::MultiheadAttentionOptions(cfg.embed_dim, cfg.num_heads)));
+    output_ = register_module("output", torch::nn::Linear(cfg.embed_dim, cfg.hidden_dim));
+}
+
+// Forward pass combining token embeddings, attention and state projection
+// tokens: [batch, seq], state: [batch, hidden_dim]
+torch::Tensor Pi0Model::forward(const torch::Tensor& tokens,
+                                 const torch::Tensor& state) {
+    auto token_emb = token_embedding_->forward(tokens); // [B, S, E]
+    auto state_proj = state_proj_->forward(state);      // [B, E]
+    state_proj = state_proj.unsqueeze(1).expand({token_emb.size(0), token_emb.size(1), cfg_.embed_dim});
+
+    auto query = token_emb.permute({1, 0, 2}); // [S, B, E]
+    auto key = query;
+    auto value = query;
+    auto attn_output = std::get<0>(attention_->forward(query, key, value));
+    attn_output = attn_output.permute({1, 0, 2}); // [B, S, E]
+
+    auto combined = attn_output + state_proj;
+    return output_->forward(combined);
+}
+
+} // namespace pi0
+} // namespace lerobot
+
+// Register with TorchScript
+TORCH_LIBRARY(pi0, m) {
+    namespace F = lerobot::pi0;
+    m.class_<F::Pi0Model>("Pi0Model")
+        .def(torch::init<F::ModelConfig>())
+        .def("forward", &F::Pi0Model::forward);
+}
+


### PR DESCRIPTION
## Summary
- implement minimal Pi0Model in C++ with embeddings, attention and linear heads
- expose model via pybind11 and register with TorchScript
- compile new module through updated CMake build

## Testing
- `pre-commit run --files src/lerobot/policies/pi0/cpp/include/pi0/model.h src/lerobot/policies/pi0/cpp/src/model.cpp src/lerobot/policies/pi0/cpp/src/bindings.cpp src/lerobot/policies/pi0/cpp/CMakeLists.txt` *(failed: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.10')*
- `pytest -q` *(failed: ValueError: mutable default <class 'lerobot.configs.types.PolicyFeature'> for field value is not allowed: use default_factory)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ac98c3f8832a85b6c753c03095f3